### PR TITLE
Use biber commands for bibliography

### DIFF
--- a/paper_template/preamble.tex
+++ b/paper_template/preamble.tex
@@ -64,3 +64,4 @@
 \titleformat*{\subsection}{\normalsize\bfseries}
 \titleformat*{\subsubsection}{\normalsize\bfseries}
 
+\usepackage{biblatex}

--- a/paper_template/sample.tex
+++ b/paper_template/sample.tex
@@ -2,6 +2,8 @@
 
 \input{preamble}
 
+\addbibresource{sample.bib}
+
 \title{Paper Template and Formatting Requirements\footnote{\protect\input{copyright}}
 }
 
@@ -282,7 +284,6 @@ document\cite{meinke} created by John Meinke.
 
 \medskip
 
-\bibliographystyle{plain}
-\bibliography{sample}
+\printbibliography
 
 \end{document}


### PR DESCRIPTION
The body of the sample says that biber commands (i.e. \printbibliography) should be used to manage the bibliography, but the sample.tex itself was using the BibTeX commands (i.e. \bibliographystyle and \bibliography).  This revision makes the content of the sample.tex match its own advice.

The original version of this template did not compile using pdflatex through TexLive on Ubuntu 20.04.2 LTS. The explicit use of biblatex and the corresponding switch to biber commands make it produce a `sample.pdf` that is the same as the one in the repository.